### PR TITLE
Expose bathymetry

### DIFF
--- a/terrain-classic-background.yml
+++ b/terrain-classic-background.yml
@@ -95,6 +95,67 @@ Layer:
       # file: landcover/LCType_z9_s3-urban-only.vrt
 
   - <<: *layer
+    name: ne_10m_rivers_lake_centerlines_scale_rank
+    id:   ne_10m_rivers_lake_centerlines_scale_rank
+    properties:
+      minzoom: 4
+      maxzoom: 8
+    Datasource:
+      <<: *postgis
+      geometry_field: geom
+      table: ne_10m_rivers_lake_centerlines_scale_rank
+      encoding: "ISO-8859-1"
+
+  - <<: *layer
+    name: ne_50m_lakes
+    id:   ne_50m_lakes
+    properties:
+      minzoom: 2
+      maxzoom: 5
+    Datasource:
+      <<: *postgis
+      geometry_field: geom
+      table: ne_50m_lakes
+      encoding: "ISO-8859-1"
+
+  - <<: *layer
+    name: ne_10m_lakes
+    id:   ne_10m_lakes
+    properties:
+      minzoom: 6
+      maxzoom: 8
+    Datasource:
+      <<: *postgis
+      geometry_field: geom
+      table: ne_10m_lakes
+      encoding: "ISO-8859-1"
+
+  - <<: *layer
+    name: ne_10m_ocean
+    id:   ne_10m_ocean
+    properties:
+      minzoom: 0
+      maxzoom: 7
+    Datasource:
+      <<: *postgis
+      geometry_field: geom
+      table: ne_10m_ocean
+      encoding: "ISO-8859-1"
+
+  - <<: *layer
+    name: ne_50m_ocean
+    id:   ne_50m_ocean
+    properties:
+      minzoom: 0
+      maxzoom: 7
+    Datasource:
+      <<: *postgis
+      geometry_field: geom
+      table: ne_50m_ocean
+      encoding: "ISO-8859-1"
+
+
+  - <<: *layer
     name: country-shapes-50m
     id:   country-shapes-50m
     class: shore
@@ -363,6 +424,37 @@ Layer:
             type,
             area
           FROM osm_landcover_z10
+          WHERE geometry && !bbox!
+        ) AS _
+
+  - <<: *layer
+    name: water
+    id:   water
+    properties:
+      minzoom: 8
+      maxzoom: 9
+    Datasource:
+      <<: *postgis
+      geometry_field: geom
+      table: water_polygons
+
+  - <<: *layer
+    name: water-bodies-low
+    id:   water-bodies-low
+    properties:
+      minzoom: 8
+      maxzoom: 9
+    Datasource:
+      <<: *postgis
+      geometry_field: geometry
+      table: >
+        (
+          SELECT
+            name,
+            type,
+            geometry,
+            area
+          FROM osm_water_areas_z10
           WHERE geometry && !bbox!
         ) AS _
 

--- a/terrain-classic-features.yml
+++ b/terrain-classic-features.yml
@@ -48,66 +48,6 @@ Stylesheet:
 Layer:
 
   - <<: *layer
-    name: ne_10m_rivers_lake_centerlines_scale_rank
-    id:   ne_10m_rivers_lake_centerlines_scale_rank
-    properties:
-      minzoom: 4
-      maxzoom: 8
-    Datasource:
-      <<: *postgis
-      geometry_field: geom
-      table: ne_10m_rivers_lake_centerlines_scale_rank
-      encoding: "ISO-8859-1"
-
-  - <<: *layer
-    name: ne_50m_lakes
-    id:   ne_50m_lakes
-    properties:
-      minzoom: 2
-      maxzoom: 5
-    Datasource:
-      <<: *postgis
-      geometry_field: geom
-      table: ne_50m_lakes
-      encoding: "ISO-8859-1"
-
-  - <<: *layer
-    name: ne_10m_lakes
-    id:   ne_10m_lakes
-    properties:
-      minzoom: 6
-      maxzoom: 8
-    Datasource:
-      <<: *postgis
-      geometry_field: geom
-      table: ne_10m_lakes
-      encoding: "ISO-8859-1"
-
-  - <<: *layer
-    name: ne_10m_ocean
-    id:   ne_10m_ocean
-    properties:
-      minzoom: 0
-      maxzoom: 7
-    Datasource:
-      <<: *postgis
-      geometry_field: geom
-      table: ne_10m_ocean
-      encoding: "ISO-8859-1"
-
-  - <<: *layer
-    name: ne_50m_ocean
-    id:   ne_50m_ocean
-    properties:
-      minzoom: 0
-      maxzoom: 7
-    Datasource:
-      <<: *postgis
-      geometry_field: geom
-      table: ne_50m_ocean
-      encoding: "ISO-8859-1"
-
-  - <<: *layer
     name: nullisland
     id:   nullisland
     class: land
@@ -140,7 +80,7 @@ Layer:
     name: water
     id:   water
     properties:
-      minzoom: 8
+      minzoom: 10
     Datasource:
       <<: *postgis
       geometry_field: geom
@@ -204,18 +144,6 @@ Layer:
           FROM osm_water_areas_z10
           WHERE geometry && !bbox!
         ) AS _
-
-  - <<: *layer
-    name: ne_10m_rivers_lake_centerlines_scale_rank
-    id:   ne_10m_rivers_lake_centerlines_scale_rank
-    properties:
-      minzoom: 4
-      maxzoom: 8
-    Datasource:
-      <<: *postgis
-      geometry_field: geom
-      table: ne_10m_rivers_lake_centerlines_scale_rank
-      encoding: "ISO-8859-1"
 
   - <<: *layer
     name: admin0-map-units-10m


### PR DESCRIPTION
Move water out of the features layer at low zooms to allow bathymetry to poke through.

Needs potential tweaking of the bathymetry shading (possibly with an additional land mask layer) as well as consideration of when it should disappear (since it gets mighty blurry around z9 anyway).

/cc @almccon 